### PR TITLE
DEV-4890 Do not store login cookie for strategies that disable storage.

### DIFF
--- a/lib/devise_login_cookie.rb
+++ b/lib/devise_login_cookie.rb
@@ -4,7 +4,9 @@ require "devise_login_cookie/strategy"
 Warden::Strategies.add(:devise_login_cookie, DeviseLoginCookie::Strategy)
 
 Warden::Manager.after_set_user except: :fetch do |user, warden, options|
-  DeviseLoginCookie::Cookie.new(warden.cookies, options[:scope]).set(user)
+  if options.fetch(:store, true)
+    DeviseLoginCookie::Cookie.new(warden.cookies, options[:scope]).set(user)
+  end
 end
 
 Warden::Manager.before_logout do |user, warden, options|
@@ -15,7 +17,7 @@ Warden::Manager.after_fetch do |record, warden, options|
   scope = options[:scope]
   cookie_name = DeviseLoginCookie::Cookie.cookie_name(scope)
   if warden.authenticated? && warden.cookies.signed[cookie_name].blank?
-    warden.logout(scope) 
+    warden.logout(scope)
     #throw :warden, :scope => scope, :message => :unauthenticated
   end
 end


### PR DESCRIPTION
Context:

Warden provides a way to add custom authentication mechanism as Strategy. And the custom strategy can control whether a sign in results a permanent login.

https://github.com/hassox/warden/blob/master/lib/warden/strategies/base.rb#L102-L106

However, the changed code always persists cookies and breaks other strategies' expected behaviour when they have #store? returning false. Added if checks prevents cookies persistence by respecting the currently winning strategy's option.